### PR TITLE
Fixes possible empty $context asignment 

### DIFF
--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -385,32 +385,24 @@ class UltimateMenu
 	public function getButtonNames(): array
 	{
 		global $context;
-
-		// Start an instant replay.
-		add_integration_function('integrate_menu_buttons', 'um_replay_menu', false);
-
+		
 		// It's expected to be present.
-		$context['user']['unread_messages'] = 0;
-
-		// Shuffle-me-not
-		$context['um_replaying_menu'] = true;
+		$context['user']['unread_messages'] = 0;		
 
 		// Load SMF's default menu context.
-		setupMenuContext();
+		setupMenuContext();		
 
-		// We are in the endgame now.
-		remove_integration_function('integrate_menu_buttons', 'um_replay_menu', false);
-
-		unset($context['um_replaying_menu']);
-
-		return $this->flatten($context['replayed_menu_buttons']);
+		return $this->flatten($context['menu_buttons']);
 	}
 
 	private function flatten(array $array, int $i = 0): array
 	{
-		$result = array();
+		global $context;
+
+		$result = [];
 		foreach ($array as $key => $value)
 		{
+			$value['title'] = !empty($buttonName) && $buttonName == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : $value['title'];
 			$result[$key] = [$i, $value['title']];
 			if (!empty($value['sub_buttons']))
 				$result += $this->flatten($value['sub_buttons'], $i + 1);

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -385,12 +385,12 @@ class UltimateMenu
 	public function getButtonNames(): array
 	{
 		global $context;
-		
+
 		// It's expected to be present.
-		$context['user']['unread_messages'] = 0;		
+		$context['user']['unread_messages'] = 0;
 
 		// Load SMF's default menu context.
-		setupMenuContext();		
+		setupMenuContext();
 
 		return $this->flatten($context['menu_buttons']);
 	}
@@ -399,7 +399,7 @@ class UltimateMenu
 	{
 		global $context;
 
-		$result = [];
+		list($result, $buttonName) = [[], $context['button_data']['name'] ?? ''];
 		foreach ($array as $key => $value)
 		{
 			$value['title'] = !empty($buttonName) && $buttonName == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : $value['title'];

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,14 +384,20 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context, $user_info;
+		global $context, $settings, $user_info;
 
 		// It's expected to be present.
 		$context['user']['unread_messages'] = 0;
 
+		// Temporarily enable the login and register buttons
+		$login_main_menu = !empty($settings['login_main_menu']) ? $settings['login_main_menu'] : false;
+		$settings['login_main_menu'] = true;
+
 		// Nullify the menu_buttons cache and then load SMF's default menu context.
 		cache_put_data('menu_buttons-' . implode('_', $user_info['groups']) . '-' . $user_info['language'], null, 90);
 		setupMenuContext();
+
+		$settings['login_main_menu'] = $login_main_menu;
 
 		return $this->flatten($context['menu_buttons']);
 	}

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,12 +384,11 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context;
+		global $context, $modSettings;
 
-		if (empty($context['um_all_buttons'])) {
-			$context['user']['unread_messages'] = $context['user']['unread_messages'] ?? 0;
-			setupMenuContext();
-		}
+		// Load SMF's default menu context.
+		cache_put_data('menu_buttons-' . implode('_', $user_info['groups']) . '-' . $user_info['language'], null, 90);
+		setupMenuContext();
 
 		return $this->flatten($context['um_all_buttons']);
 	}

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -395,7 +395,7 @@ class UltimateMenu
 
 	private function flatten(array $array, int $i = 0): array
 	{
-		global $context;
+		global $settings, $context;
 
 		$result = [];
 		foreach ($array as $key => $value) {

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,7 +384,14 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context;
+		global $context, $user_info, $settings;
+
+		// This should only occur during testing
+		if (empty($context['um_all_buttons'])) {
+			list($settings['login_main_menu'], $user_info['is_guest']) = [true, true];
+			setupMenuContext();
+			$context['um_all_buttons'] = $context['menu_buttons'];
+		}
 
 		return $this->flatten($context['um_all_buttons']);
 	}

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -397,11 +397,11 @@ class UltimateMenu
 	{
 		global $context;
 
-		list($result, $loginMainMenu, $buttonName) = [[], ['login', 'logout', 'signup'], $context['button_data']['name'] ?? ''];
+		list($result, $buttonName) = [[], $context['button_data']['name'] ?? ''];
 		foreach ($array as $key => $value)
 		{
 			$value['title'] = !empty($buttonName) && $buttonName == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : $value['title'];
-			$value['title'] = in_array($key, $loginMainMenu) ? '<span class="um_login">&ensp;&#8608;&nbsp;' . $value['title'] . '</span>' : $value['title'];
+			$value['title'] = in_array($key, ['login', 'logout', 'signup']) ? '<span class="um_login">&ensp;&#8608;&nbsp;' . $value['title'] . '</span>' : $value['title'];
 			$result[$key] = [$i, $value['title']];
 			if (!empty($value['sub_buttons']))
 				$result += $this->flatten($value['sub_buttons'], $i + 1);

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,12 +384,13 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context;
+		global $context, $user_info;
 
 		// It's expected to be present.
 		$context['user']['unread_messages'] = 0;
 
-		// Load SMF's default menu context.
+		// Nullify the menu_buttons cache and then load SMF's default menu context.
+		cache_put_data('menu_buttons-' . implode('_', $user_info['groups']) . '-' . $user_info['language'], null, 90);
 		setupMenuContext();
 
 		return $this->flatten($context['menu_buttons']);

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -399,11 +399,10 @@ class UltimateMenu
 
 		$result = [];
 		foreach ($array as $key => $value) {
-			$value['title'] = 'um_button_' . ($context['button_data']['id'] ?? 0) == $key ?
-				'<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : (
-				in_array($key, ['login', 'logout', 'signup']) ? '<span class="um_login">&#129082;&nbsp;' . $value['title'] . '</span>' : $value['title']
-			);
-			$result[$key] = [$i, $value['title']];
+			$result[$key] = [$i, 'um_button_' . ($context['button_data']['id'] ?? 0) == $key ?
+				'<span class="um_current">&#10146;&nbsp;' . $value['title'] . '</span>' : (
+				in_array($key, ['login', 'logout', 'signup']) ? '<span class="um_login">&#' . (empty($settings['login_main_menu']) ? '11089' : '11090') . ';&nbsp;' . $value['title'] . '</span>' : $value['title']
+			)];
 			if (!empty($value['sub_buttons']))
 				$result += $this->flatten($value['sub_buttons'], $i + 1);
 		}

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,14 +384,10 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context, $user_info, $settings;
-
-		// This should only occur during testing
-		if (empty($context['um_all_buttons'])) {
-			add_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
-			setupMenuContext();
-			remove_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
-		}
+		global $context;
+		
+		add_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
+		setupMenuContext();			
 
 		return $this->flatten($context['um_all_buttons']);
 	}

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,11 +384,12 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context, $modSettings;
+		global $context;
 
-		add_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
-		setupMenuContext();
-		remove_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
+		if (empty($context['um_all_buttons'])) {
+			$context['user']['unread_messages'] = $context['user']['unread_messages'] ?? 0;
+			setupMenuContext();
+		}
 
 		return $this->flatten($context['um_all_buttons']);
 	}

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -397,10 +397,10 @@ class UltimateMenu
 	{
 		global $context;
 
-		list($result, $buttonName) = [[], $context['button_data']['name'] ?? ''];
+		$result = [];
 		foreach ($array as $key => $value)
 		{
-			$value['title'] = !empty($buttonName) && $buttonName == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : $value['title'];
+			$value['title'] = !empty($context['button_data']['name']) && $context['button_data']['name'] == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : $value['title'];
 			$value['title'] = in_array($key, ['login', 'logout', 'signup']) ? '<span class="um_login">&ensp;&#8608;&nbsp;' . $value['title'] . '</span>' : $value['title'];
 			$result[$key] = [$i, $value['title']];
 			if (!empty($value['sub_buttons']))

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,22 +384,9 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context, $settings, $user_info;
+		global $context;
 
-		// It's expected to be present.
-		$context['user']['unread_messages'] = 0;
-
-		// Temporarily enable the login and register buttons
-		$login_main_menu = !empty($settings['login_main_menu']) ? $settings['login_main_menu'] : false;
-		$settings['login_main_menu'] = true;
-
-		// Nullify the menu_buttons cache and then load SMF's default menu context.
-		cache_put_data('menu_buttons-' . implode('_', $user_info['groups']) . '-' . $user_info['language'], null, 90);
-		setupMenuContext();
-
-		$settings['login_main_menu'] = $login_main_menu;
-
-		return $this->flatten($context['menu_buttons']);
+		return $this->flatten($context['um_all_buttons']);
 	}
 
 	private function flatten(array $array, int $i = 0): array

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -398,10 +398,11 @@ class UltimateMenu
 		global $context;
 
 		$result = [];
-		foreach ($array as $key => $value)
-		{
-			$value['title'] = !empty($context['button_data']['name']) && $context['button_data']['name'] == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : $value['title'];
-			$value['title'] = in_array($key, ['login', 'logout', 'signup']) ? '<span class="um_login">&ensp;&#8608;&nbsp;' . $value['title'] . '</span>' : $value['title'];
+		foreach ($array as $key => $value) {
+			$value['title'] = 'um_button_' . ($context['button_data']['id'] ?? 0) == $key ?
+				'<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : (
+				in_array($key, ['login', 'logout', 'signup']) ? '<span class="um_login">&#129082;&nbsp;' . $value['title'] . '</span>' : $value['title']
+			);
 			$result[$key] = [$i, $value['title']];
 			if (!empty($value['sub_buttons']))
 				$result += $this->flatten($value['sub_buttons'], $i + 1);

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -388,9 +388,9 @@ class UltimateMenu
 
 		// This should only occur during testing
 		if (empty($context['um_all_buttons'])) {
-			list($settings['login_main_menu'], $user_info['is_guest']) = [true, true];
+			add_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
 			setupMenuContext();
-			$context['um_all_buttons'] = $context['menu_buttons'];
+			remove_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
 		}
 
 		return $this->flatten($context['um_all_buttons']);

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -403,7 +403,7 @@ class UltimateMenu
 		list($result, $buttonName) = [[], $context['button_data']['name'] ?? ''];
 		foreach ($array as $key => $value)
 		{
-			$value['title'] = !empty($buttonName) && $buttonName == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : $value['title'];
+			$value['title'] = !empty($value['title']) && !empty($buttonName) && $buttonName == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : ($value['title'] ?? '');
 			$result[$key] = [$i, $value['title']];
 			if (!empty($value['sub_buttons']))
 				$result += $this->flatten($value['sub_buttons'], $i + 1);

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -397,10 +397,11 @@ class UltimateMenu
 	{
 		global $context;
 
-		list($result, $buttonName) = [[], $context['button_data']['name'] ?? ''];
+		list($result, $loginMainMenu, $buttonName) = [[], ['login', 'logout', 'signup'], $context['button_data']['name'] ?? ''];
 		foreach ($array as $key => $value)
 		{
-			$value['title'] = !empty($value['title']) && !empty($buttonName) && $buttonName == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : ($value['title'] ?? '');
+			$value['title'] = !empty($buttonName) && $buttonName == $value['title'] ? '<span class="um_current">&ensp;&#10146;&nbsp;' . $value['title'] . '</span>' : $value['title'];
+			$value['title'] = in_array($key, $loginMainMenu) ? '<span class="um_login">&ensp;&#8608;&nbsp;' . $value['title'] . '</span>' : $value['title'];
 			$result[$key] = [$i, $value['title']];
 			if (!empty($value['sub_buttons']))
 				$result += $this->flatten($value['sub_buttons'], $i + 1);

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,10 +384,11 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context;
-		
+		global $context, $modSettings;
+
 		add_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
-		setupMenuContext();			
+		setupMenuContext();
+		remove_integration_function('integrate_menu_buttons', 'um_backup_menu', false);
 
 		return $this->flatten($context['um_all_buttons']);
 	}

--- a/src/Class-UltimateMenu.php
+++ b/src/Class-UltimateMenu.php
@@ -384,7 +384,7 @@ class UltimateMenu
 	 */
 	public function getButtonNames(): array
 	{
-		global $context, $modSettings;
+		global $context, $user_info;
 
 		// Load SMF's default menu context.
 		cache_put_data('menu_buttons-' . implode('_', $user_info['groups']) . '-' . $user_info['language'], null, 90);

--- a/src/ManageUltimateMenu.php
+++ b/src/ManageUltimateMenu.php
@@ -351,7 +351,7 @@ class ManageUltimateMenu
 
 	public function EditButton(): void
 	{
-		global $context, $txt;
+		global $smcFunc, $context, $txt;
 
 		$row = isset($_GET['in']) ? $this->um->fetchButton($_GET['in']) : [];
 		if (empty($row))
@@ -359,7 +359,7 @@ class ManageUltimateMenu
 
 		$context['button_data'] = [
 			'id' => $row['id'],
-			'name' => $row['name'],
+			'name' => $smcFunc['htmlspecialchars']($row['name']),
 			'target' => $row['target'],
 			'type' => $row['type'],
 			'position' => $row['position'],

--- a/src/ManageUltimateMenu.template.php
+++ b/src/ManageUltimateMenu.template.php
@@ -87,7 +87,7 @@ function template_main(): void
 			'
 								<option value="%s"%s>%s</option>',
 			$idx,
-			$sel($context['button_data']['parent'] == $idx, 'selected'),
+			strpos($title[1], '<span class="um_current">') !== false ? 'disabled' : $sel($context['button_data']['parent'] == $idx, 'selected'),
 			str_repeat('&emsp;', $title[0] * 2) . $title[1]
 		);
 

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -15,7 +15,7 @@ function um_load_menu(&$menu_buttons): void
 	global $context, $modSettings, $smcFunc, $user_info, $scripturl;
 
 	// Make damn sure we ALWAYS load last. Priority: 100!
-	if (!isset($context['um_replaying_menu']) && substr($modSettings['integrate_menu_buttons'], -12) !== 'um_load_menu')
+	if (substr($modSettings['integrate_menu_buttons'], -12) !== 'um_load_menu')
 	{
 		remove_integration_function('integrate_menu_buttons', 'um_load_menu');
 		add_integration_function('integrate_menu_buttons', 'um_load_menu');
@@ -39,13 +39,6 @@ function um_load_menu(&$menu_buttons): void
 
 		recursive_button($temp_menu, $menu_buttons, $row['parent'], $row['position'], $key);
 	}
-}
-
-function um_replay_menu(&$menu_buttons)
-{
-	global $context;
-
-	$context['replayed_menu_buttons'] = $menu_buttons;
 }
 
 function recursive_button(array $needle, array &$haystack, $insertion_point, $where, $key): void

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -38,7 +38,7 @@ function um_load_menu(&$menu_buttons): void
 		];
 
 		recursive_button($temp_menu, $menu_buttons, $row['parent'], $row['position'], $key);
-		$context['um_all_buttons'] = $menu_buttons;
+		$context['um_all_buttons'] = $context['um_all_buttons'] ?? $menu_buttons;
 	}
 }
 

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -38,6 +38,7 @@ function um_load_menu(&$menu_buttons): void
 		];
 
 		recursive_button($temp_menu, $menu_buttons, $row['parent'], $row['position'], $key);
+		$context['um_all_buttons'] = $menu_buttons;
 	}
 }
 

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -19,7 +19,12 @@ function um_load_menu(&$menu_buttons): void
 	{
 		remove_integration_function('integrate_menu_buttons', 'um_load_menu');
 		add_integration_function('integrate_menu_buttons', 'um_load_menu');
-		$context['um_all_buttons'] = $menu_buttons;
+		$integrate_menu_buttons = explode(',', $modSettings['integrate_menu_buttons']);
+		if (($key = array_search('um_load_menu', $integrate_menu_buttons)) !== false) {
+			unset($integrate_menu_buttons[$key]);
+			$integrate_menu_buttons[] = 'um_load_menu';
+			$modSettings['integrate_menu_buttons'] = implode(',', $integrate_menu_buttons);
+		}
 
 		return;
 	}

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -44,7 +44,6 @@ function um_load_menu(&$menu_buttons): void
 		];
 
 		recursive_button($temp_menu, $menu_buttons, $row['parent'], $row['position'], $key);
-		$context['um_all_buttons'] = $menu_buttons;
 	}
 }
 

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -48,6 +48,13 @@ function um_load_menu(&$menu_buttons): void
 	}
 }
 
+function um_backup_menu(&$menu_buttons): void
+{
+	global $context;
+
+	$context['um_all_buttons'] = $menu_buttons;
+}
+
 function recursive_button(array $needle, array &$haystack, $insertion_point, $where, $key): void
 {
 	foreach ($haystack as $area => &$info)

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -44,6 +44,7 @@ function um_load_menu(&$menu_buttons): void
 		];
 
 		recursive_button($temp_menu, $menu_buttons, $row['parent'], $row['position'], $key);
+		$context['um_all_buttons'] = $menu_buttons;
 	}
 }
 

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -19,12 +19,6 @@ function um_load_menu(&$menu_buttons): void
 	{
 		remove_integration_function('integrate_menu_buttons', 'um_load_menu');
 		add_integration_function('integrate_menu_buttons', 'um_load_menu');
-		$integrate_menu_buttons = explode(',', $modSettings['integrate_menu_buttons']);
-		if (($key = array_search('um_load_menu', $integrate_menu_buttons)) !== false) {
-			unset($integrate_menu_buttons[$key]);
-			$integrate_menu_buttons[] = 'um_load_menu';
-			$modSettings['integrate_menu_buttons'] = implode(',', $integrate_menu_buttons);
-		}
 
 		return;
 	}
@@ -44,14 +38,8 @@ function um_load_menu(&$menu_buttons): void
 		];
 
 		recursive_button($temp_menu, $menu_buttons, $row['parent'], $row['position'], $key);
+		$context['um_all_buttons'] = $menu_buttons;
 	}
-}
-
-function um_backup_menu(&$menu_buttons): void
-{
-	global $context;
-
-	$context['um_all_buttons'] = $menu_buttons;
 }
 
 function recursive_button(array $needle, array &$haystack, $insertion_point, $where, $key): void

--- a/src/Subs-UltimateMenu.php
+++ b/src/Subs-UltimateMenu.php
@@ -19,6 +19,7 @@ function um_load_menu(&$menu_buttons): void
 	{
 		remove_integration_function('integrate_menu_buttons', 'um_load_menu');
 		add_integration_function('integrate_menu_buttons', 'um_load_menu');
+		$context['um_all_buttons'] = $menu_buttons;
 
 		return;
 	}
@@ -38,7 +39,7 @@ function um_load_menu(&$menu_buttons): void
 		];
 
 		recursive_button($temp_menu, $menu_buttons, $row['parent'], $row['position'], $key);
-		$context['um_all_buttons'] = $context['um_all_buttons'] ?? $menu_buttons;
+		$context['um_all_buttons'] = $menu_buttons;
 	}
 }
 

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -311,7 +311,7 @@ final class Test extends TestCase
 
 	public function testListButtons(): void
 	{
-		global $modSettings;
+		global $context, $modSettings;
 
 		$modSettings['um_count'] = 2;
 		$modSettings['um_button_2'] = '{"name":"Test","type":"forum","target":"_self","position":"before","link":"t","active":true,"groups":[-1,0,2],"parent":"signup"}';

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -311,7 +311,7 @@ final class Test extends TestCase
 
 	public function testListButtons(): void
 	{
-		global $context, $modSettings;
+		global $modSettings;
 
 		$modSettings['um_count'] = 2;
 		$modSettings['um_button_2'] = '{"name":"Test","type":"forum","target":"_self","position":"before","link":"t","active":true,"groups":[-1,0,2],"parent":"signup"}';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,7 @@ require_once './vendor/autoload.php';
 // What are you doing here, SMF?
 define('SMF', 1);
 
-global $context, $scripturl;
+global $context, $scripturl, $user_info, $modSettings;
 $user_info = ['is_admin' => true, 'is_guest' => false, 'language' => '', 'groups' => [0], 'permissions' => []];
 $context = [
 	'user' => ['can_mod' => true, 'is_guest' => false, 'id' => 1],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,7 @@ require_once './vendor/autoload.php';
 // What are you doing here, SMF?
 define('SMF', 1);
 
-global $context, $settings, $scripturl;
+global $context, $scripturl;
 $user_info = ['is_admin' => true, 'is_guest' => false, 'language' => '', 'groups' => [0], 'permissions' => []];
 $context = [
 	'user' => ['can_mod' => true, 'is_guest' => false, 'id' => 1],
@@ -24,7 +24,6 @@ $context = [
 ];
 $modSettings = ['lastActive' => 0, 'settings_updated' => 0, 'postmod_active' => false];
 $scripturl = dirname(__DIR__);
-$settings['login_main_menu'] = true;
 
 $smcFunc['db_query'] = function ($name, $query, $args)
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,7 @@ require_once './vendor/autoload.php';
 // What are you doing here, SMF?
 define('SMF', 1);
 
-global $context, $scripturl, $user_info, $modSettings;
+global $smcFunc, $context, $scripturl, $user_info, $modSettings;
 $user_info = ['is_admin' => true, 'is_guest' => false, 'language' => '', 'groups' => [0], 'permissions' => []];
 $context = [
 	'user' => ['can_mod' => true, 'is_guest' => false, 'id' => 1],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,7 @@ require_once './vendor/autoload.php';
 // What are you doing here, SMF?
 define('SMF', 1);
 
-global $context;
+global $context, $settings, $scripturl;
 $user_info = ['is_admin' => true, 'is_guest' => false, 'language' => '', 'groups' => [0], 'permissions' => []];
 $context = [
 	'user' => ['can_mod' => true, 'is_guest' => false, 'id' => 1],
@@ -23,9 +23,8 @@ $context = [
 	'admin_menu_name' => '',
 ];
 $modSettings = ['lastActive' => 0, 'settings_updated' => 0, 'postmod_active' => false];
-
-global $scripturl; 
 $scripturl = dirname(__DIR__);
+$settings['login_main_menu'] = true;
 
 $smcFunc['db_query'] = function ($name, $query, $args)
 {


### PR DESCRIPTION
Key factors with this PR:

- testing revealed assigning the nav menu to the unique context key & expecting it to be available after calling the hook was failing in some scenarios
- using the SMF assigned context key works as expected
- highlighting the current edited UM button & making that option disabled (unavailable for selection) seems prudent
- this is a bug therefore I posted it apart from my revamp 